### PR TITLE
Fix Issue #8: Chameleon crash when ~/.config/chameleon/ and ~/.config/chameleon/config.yaml path doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/chameleon.py
 	@echo "removed $(DESTDIR)$(PREFIX)/bin/chameleon.py"
-	rm -f $(DESTDIR)$(CONFIG)/chameleon/config.yaml
-	@echo "removed $(DESTDIR)$(CONFIG)/chameleon/config.yaml"
+	rm -rf $(DESTDIR)$(CONFIG)/chameleon
+	@echo "removed $(DESTDIR)$(CONFIG)/chameleon"
 	$(PIPVER) uninstall whichcraft
 .PHONY: install uninstall pipversion

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,7 @@ install:
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/chameleon.py
 	@echo "removed $(DESTDIR)$(PREFIX)/bin/chameleon.py"
+	rm -f $(DESTDIR)$(CONFIG)/chameleon/config.yaml
+	@echo "removed $(DESTDIR)$(CONFIG)/chameleon/config.yaml"
 	$(PIPVER) uninstall whichcraft
 .PHONY: install uninstall pipversion

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 .POSIX:
 PREFIX = ~/.local
+CONFIG = ~/.config
 PIPVER = `command -v pip3 || command -v pip`
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp -f chameleon.py $(DESTDIR)$(PREFIX)/bin/chameleon.py
 	@echo "chameleon.py has been installed to $(DESTDIR)$(PREFIX)/bin/chameleon.py"
+	mkdir -p $(DESTDIR)$(CONFIG)/chameleon
+	cp -f config.yaml $(DESTDIR)$(CONFIG)/chameleon/config.yaml
+	@echo "config file for chameleon.py created in $(DESTDIR)$(PREFIX)/config/config.yaml"
 	@echo "installing $(PIPVER) dependencies"
 	@$(PIPVER) install --user whichcraft || echo "dependencies couldn't be installed install pip and rerun"
 uninstall:


### PR DESCRIPTION
As explained in the issue, chameleon.py would refuse to run if ```~/.config/chameleon/config.yaml``` was not a valid file/ directory. I updated the makefile to add this directory and copy the example config.yaml to it from the repo so that the script runs properly for the user when they install it using ```make install```. I have also updated ```make unisntall``` to remove the chameleon directory under ```~/.config``` in case the user wants to uninstall the script.